### PR TITLE
Feat/scroll pagesize

### DIFF
--- a/src/Pages/Category/Container.js
+++ b/src/Pages/Category/Container.js
@@ -191,7 +191,7 @@ const Container = () => {
     const querystring = qs.stringify(_condition, { arrayFormat: 'comma' });
     navigate(`?${querystring}`, { replace: true });
 
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('access_token');
     const option = {
       method: 'GET',
       headers: {
@@ -254,7 +254,7 @@ const Container = () => {
   }, [productCnt, currentPage]);
 
   const changeLike = ({ id, isLike }) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('access_token');
 
     if (!token) {
       navigate({

--- a/src/Pages/Category/Container.js
+++ b/src/Pages/Category/Container.js
@@ -15,6 +15,7 @@ const Container = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const [isInit, setIsInit] = React.useState(true);
   const loading = React.useRef(false);
 
   let {
@@ -204,6 +205,30 @@ const Container = () => {
       option.headers.authorization = `${token}`;
     }
 
+    if (isInit) {
+      _condition.pageSize = currentPage;
+      _condition.currentPage = 1;
+      setIsInit(false);
+      fetch(
+        `http://133.186.208.125:3000/products/category?${getQueryString(
+          _condition
+        )}`,
+        option
+      )
+        .then((res) => res.json())
+        .then(({ list, currentPage, productCnt }) => {
+          currentPage = Number(currentPage);
+          setProducts(list);
+          setCurrentPage(currentPage);
+          setProductCnt(productCnt);
+          loading.current = false;
+
+          const scrollY = localStorage.getItem('categoryScroll');
+          window.scrollTo(0, scrollY);
+        });
+      return;
+    }
+
     fetch(
       `http://133.186.208.125:3000/products/category?${getQueryString(
         _condition
@@ -217,7 +242,6 @@ const Container = () => {
           if (currentPage == 1) return list;
           return [...prodtucts, ...list];
         });
-        setCurrentPage(currentPage);
         setProductCnt(productCnt);
         loading.current = false;
       });
@@ -254,6 +278,18 @@ const Container = () => {
       window.removeEventListener('scroll', infiniteScroll, true);
     };
   }, [productCnt, currentPage]);
+
+  const saveScroll = () => {
+    const scrollY = window.scrollY;
+    localStorage.setItem('categoryScroll', scrollY);
+  };
+  React.useEffect(() => {
+    window.addEventListener('scroll', saveScroll, true);
+
+    return () => {
+      window.removeEventListener('scroll', saveScroll, true);
+    };
+  }, []);
 
   const changeLike = ({ id, isLike }) => {
     const token = localStorage.getItem('access_token');
@@ -302,9 +338,7 @@ const Container = () => {
   };
 
   const gotoDetail = (id) => {
-    navigate({
-      pathname: `/detail/${id}`,
-    });
+    return (window.location.href = `/detail/${id}`);
   };
 
   return (

--- a/src/Pages/Category/Container.js
+++ b/src/Pages/Category/Container.js
@@ -22,7 +22,7 @@ const Container = () => {
     brand: locationBrand,
     order: locationOrder,
     event: locationEvent,
-    page: locationPage,
+    currentPage: locationPage,
   } = qs.parse(location.search.slice(1), { arrayFormat: 'comma' });
 
   if (locationBrand && !Array.isArray(locationBrand))
@@ -156,14 +156,16 @@ const Container = () => {
   }, []);
 
   const [products, setProducts] = React.useState([]);
-  const [currentPage, setCurrentPage] = React.useState(locationPage || 1);
+  const [currentPage, setCurrentPage] = React.useState(
+    Number(locationPage) || 1
+  );
   const [productCnt, setProductCnt] = React.useState(0);
 
   React.useEffect(() => {
     loading.current = true;
     const _condition = {};
 
-    _condition.page = currentPage;
+    _condition.currentPage = currentPage;
     _condition.brand = brand
       .filter((item) => item.selected)
       .map((item) => {

--- a/src/Pages/Detail/Container.js
+++ b/src/Pages/Detail/Container.js
@@ -23,7 +23,7 @@ const Container = () => {
   });
 
   const changeLike = ({ id, isLike }) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('access_token');
     console.log(id);
     if (!token) {
       navigate({
@@ -63,7 +63,7 @@ const Container = () => {
   };
 
   React.useEffect(() => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('access_token');
     const options = {
       method: 'GET',
       headers: {},

--- a/src/Pages/Login/Container.js
+++ b/src/Pages/Login/Container.js
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import View from './View';
 
 const Container = () => {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem('access_token');
   const navigate = useNavigate();
 
   const REST_API_KEY = React.useRef('23c0a0c03900fcb72185e2dd8ecc9df3');
@@ -14,7 +14,6 @@ const Container = () => {
   );
   React.useEffect(() => {
     if (token == 'undefined') {
-      console.log('ddd');
       navigate({
         pathname: '/',
       });

--- a/src/Pages/MyLike/Container.js
+++ b/src/Pages/MyLike/Container.js
@@ -20,6 +20,7 @@ const Container = () => {
       ? localStorage.getItem('access_token')
       : undefined
   );
+  const [isInit, setIsInit] = React.useState(true);
   const loading = React.useRef(false);
 
   let {
@@ -108,6 +109,13 @@ const Container = () => {
       });
   }, [filter, isEvent]);
 
+  React.useEffect(() => {
+    if (isInit) {
+      const scrollY = localStorage.getItem('mylikeScroll');
+      window.scrollTo(0, scrollY);
+    }
+  }, [products]);
+
   const changeLike = ({ id, isLike }) => {
     const token = localStorage.getItem('access_token');
     if (!token) {
@@ -154,15 +162,25 @@ const Container = () => {
   };
 
   const gotoDetail = (id) => {
-    navigate({
-      pathname: `/detail/${id}`,
-    });
+    return (window.location.href = `/detail/${id}`);
   };
 
   const gotoLogin = React.useCallback(() => {
     navigate({
       pathname: '/login',
     });
+  }, []);
+
+  const saveScroll = () => {
+    const scrollY = window.scrollY;
+    localStorage.setItem('mylikeScroll', scrollY);
+  };
+  React.useEffect(() => {
+    window.addEventListener('scroll', saveScroll, true);
+
+    return () => {
+      window.removeEventListener('scroll', saveScroll, true);
+    };
   }, []);
 
   return (

--- a/src/Pages/MyLike/Container.js
+++ b/src/Pages/MyLike/Container.js
@@ -16,8 +16,8 @@ const Container = () => {
   const location = useLocation();
 
   const token = React.useRef(
-    localStorage.getItem('token') !== 'undefined'
-      ? localStorage.getItem('token')
+    localStorage.getItem('access_token') !== 'undefined'
+      ? localStorage.getItem('access_token')
       : undefined
   );
   const loading = React.useRef(false);
@@ -109,7 +109,7 @@ const Container = () => {
   }, [filter, isEvent]);
 
   const changeLike = ({ id, isLike }) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('access_token');
     if (!token) {
       navigate({
         pathname: '/login',

--- a/src/Pages/SearchResult/Container.js
+++ b/src/Pages/SearchResult/Container.js
@@ -15,7 +15,7 @@ const Container = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const token = React.useRef(localStorage.getItem('token'));
+  const token = React.useRef(localStorage.getItem('access_token'));
   const loading = React.useRef(false);
 
   const mylikeList = React.useRef([]);
@@ -221,7 +221,7 @@ const Container = () => {
     }
   });
 
- const gotoDetail = React.useCallback((id) => {
+  const gotoDetail = React.useCallback((id) => {
     navigate({
       pathname: `/detail/${id}`,
     });

--- a/src/Pages/SearchResult/Container.js
+++ b/src/Pages/SearchResult/Container.js
@@ -225,9 +225,7 @@ const Container = () => {
   });
 
   const gotoDetail = React.useCallback((id) => {
-    navigate({
-      pathname: `/detail/${id}`,
-    });
+    return (window.location.href = `/detail/${id}`);
   });
 
   React.useEffect(() => {

--- a/src/Pages/SearchResult/Container.js
+++ b/src/Pages/SearchResult/Container.js
@@ -283,6 +283,9 @@ const Container = () => {
           setProducts(_list);
           setProductCnt(productCnt);
           loading.current = false;
+
+          const scrollY = localStorage.getItem('searchresultScroll');
+          window.scrollTo(0, scrollY);
         });
       return;
     }
@@ -345,6 +348,18 @@ const Container = () => {
       window.removeEventListener('scroll', infiniteScroll, true);
     };
   }, [currentPage, productCnt]);
+
+  const saveScroll = () => {
+    const scrollY = window.scrollY;
+    localStorage.setItem('searchresultScroll', scrollY);
+  };
+  React.useEffect(() => {
+    window.addEventListener('scroll', saveScroll, true);
+
+    return () => {
+      window.removeEventListener('scroll', saveScroll, true);
+    };
+  }, []);
 
   return (
     <View


### PR DESCRIPTION
[Front] 스크롤 유지
pageSize 로 처음 진입시 currentpage * 10만큼 한꺼번에 데이터 불러오기
스크롤 위치 localstorage에 저장
navigate 사용에서 location.href 사용으로 상세 페이지이동(뒤로 가기할때 스크롤 위치 0으로 리셋 되는 문제를 위해서)

- 검색 결과 페이지
- 찜리스트 페이지
- 카테고리 페이지(api 에서 pageSize  적용후 테스트 필요)