### PR TITLE
♻️ [Refactor] Delete goToDetail

### DIFF
--- a/src/Common/PopularProducts/View.js
+++ b/src/Common/PopularProducts/View.js
@@ -77,6 +77,7 @@ const View = ({
           popularItems.map((item, i) => (
             <Item key={i}>
               <Product
+                id={item.id}
                 img={item.imageUrl}
                 title={item.name}
                 store={item.brand}

--- a/src/Common/Product/Product.js
+++ b/src/Common/Product/Product.js
@@ -1,5 +1,6 @@
 import * as S from './Product.styles';
 import NoImg from './img/no-img.svg';
+import { useNavigate } from 'react-router-dom';
 
 const Product = ({
   id,
@@ -13,17 +14,15 @@ const Product = ({
   like,
   saleend,
   changeLike = () => {},
-  gotoDetail = () => {},
 }) => {
+  const navigate = useNavigate();
   return (
     <S.Product size={size} saleend={saleend}>
       <S.ImgBox size={size}>
         <S.Img
           src={img}
           alt={title}
-          onClick={() => {
-            gotoDetail(id);
-          }}
+          onClick={() => navigate(`/detail/${id}`)}
           onError={(e) => e.target.src = NoImg}
         />
         <S.Plus plus={plus}>
@@ -40,9 +39,7 @@ const Product = ({
       <S.Info
         size={size}
         saleend={saleend}
-        onClick={() => {
-          gotoDetail(id);
-        }}
+        onClick={() => navigate(`/detail/${id}`)}
       >
         <S.StoreType type={store}>
           {store == 'GS' || store == 'gs25'

--- a/src/Pages/Category/Container.js
+++ b/src/Pages/Category/Container.js
@@ -337,10 +337,6 @@ const Container = () => {
     }
   };
 
-  const gotoDetail = (id) => {
-    return (window.location.href = `/detail/${id}`);
-  };
-
   return (
     <View
       condition={condition}
@@ -359,7 +355,6 @@ const Container = () => {
       currentPage={currentPage}
       getMoreProducts={getMoreProducts}
       changeLike={changeLike}
-      gotoDetail={gotoDetail}
     />
   );
 };

--- a/src/Pages/Category/View.js
+++ b/src/Pages/Category/View.js
@@ -35,7 +35,6 @@ const View = ({
   currentPage,
   getMoreProducts,
   changeLike,
-  gotoDetail,
 }) => {
   return (
     <Layout header='sub' title='카테고리' bottomnav={true}>
@@ -96,7 +95,6 @@ const View = ({
                 plus={DATA_REVERSE.event[product.eventType]}
                 price={product.price}
                 like={product.isLike}
-                gotoDetail={gotoDetail}
                 changeLike={changeLike}
               />
             </Item>

--- a/src/Pages/MyLike/Container.js
+++ b/src/Pages/MyLike/Container.js
@@ -161,10 +161,6 @@ const Container = () => {
     }
   };
 
-  const gotoDetail = (id) => {
-    return (window.location.href = `/detail/${id}`);
-  };
-
   const gotoLogin = React.useCallback(() => {
     navigate({
       pathname: '/login',
@@ -197,7 +193,6 @@ const Container = () => {
       categoryDeleteChoice={categoryDeleteChoice}
       products={products}
       changeLike={changeLike}
-      gotoDetail={gotoDetail}
       isLogin={token.current}
       gotoLogin={gotoLogin}
     />

--- a/src/Pages/MyLike/View.js
+++ b/src/Pages/MyLike/View.js
@@ -27,7 +27,6 @@ const View = ({
   brandDeleteChoice,
   filter,
   changeLike,
-  gotoDetail,
   products,
   isLogin,
   gotoLogin,
@@ -93,7 +92,6 @@ const View = ({
                       price={product.price}
                       like={product.isLike}
                       changeLike={changeLike}
-                      gotoDetail={gotoDetail}
                     />
                   </Item>
                 );

--- a/src/Pages/SearchResult/Container.js
+++ b/src/Pages/SearchResult/Container.js
@@ -224,10 +224,6 @@ const Container = () => {
     }
   });
 
-  const gotoDetail = React.useCallback((id) => {
-    return (window.location.href = `/detail/${id}`);
-  });
-
   React.useEffect(() => {
     loading.current = true;
     const _condition = {};
@@ -380,7 +376,6 @@ const Container = () => {
       products={products}
       productCnt={productCnt}
       changeLike={changeLike}
-      gotoDetail={gotoDetail}
     />
   );
 };

--- a/src/Pages/SearchResult/View.js
+++ b/src/Pages/SearchResult/View.js
@@ -34,7 +34,6 @@ const View = ({
   products,
   productCnt,
   changeLike,
-  gotoDetail,
 }) => {
   return (
     <Layout
@@ -122,7 +121,6 @@ const View = ({
                 plus={DATA_REVERSE.event[product.eventtype]}
                 price={product.price}
                 like={product.isLike}
-                gotoDetail={gotoDetail}
                 changeLike={changeLike}
               />
             </Item>


### PR DESCRIPTION
- 상품 클릭 시 상품 상세 페이지로 이동하는 로직은 모두 동일하나 페이지마다 함수를 만들어 넘겨주고 있음
- goToDetail props를 모두 지우고 공통 컴포넌트 안에서 onClick 이벤트로 처리