### PR TITLE
✏️  [Fix] prevent requests in n(currentPage) times - Category

### DIFF
--- a/src/Pages/Category/Container.js
+++ b/src/Pages/Category/Container.js
@@ -219,7 +219,6 @@ const Container = () => {
         .then(({ list, currentPage, productCnt }) => {
           currentPage = Number(currentPage);
           setProducts(list);
-          setCurrentPage(currentPage);
           setProductCnt(productCnt);
           loading.current = false;
 


### PR DESCRIPTION
[Front] 카테고리 페이지에서 최초 진입시 curentpage 만큼 불필요한 재요청이 일어나는 오류수정